### PR TITLE
spec.js: Inline beforeEach()'s code into it()

### DIFF
--- a/tests/spec/spec.js
+++ b/tests/spec/spec.js
@@ -1,10 +1,12 @@
 describe('ColumnCopy', function() {
   function runTest(fixtureName) {
-    var rows;
-    var spec;
-
-    beforeEach(function() {
-      var fixture, m, $table, _ColumnCopy
+    it('correctly get values via ColumnCopy.getValuesForTable: ' + fixtureName, function() {
+      var fixture;
+      var m;
+      var spec;
+      var $table;
+      var _ColumnCopy;
+      var rows;
 
       jasmine.getFixtures().fixturesPath = './';
       fixture = readFixtures(fixtureName);
@@ -22,9 +24,6 @@ describe('ColumnCopy', function() {
       };
 
       rows = _ColumnCopy.getValuesForTable($table);
-    });
-
-    it('correctly get values via ColumnCopy.getValuesForTable: ' + fixtureName, function() {
       expect(rows).toEqual(spec.rows);
     });
   }


### PR DESCRIPTION
Without this change, some classes of problems cause *all* tests
to fail, not only the test with the problem in question.  One
case where this can happen is if the test file's JSON contains a
syntax error.